### PR TITLE
Allow cryptotool secured secrets to be decrypted

### DIFF
--- a/src/jwtauthhandler/dependency-reduced-pom.xml
+++ b/src/jwtauthhandler/dependency-reduced-pom.xml
@@ -63,6 +63,37 @@
       <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
+      <id>wso2-nexus</id>
+      <name>WSO2 Public Repository</name>
+      <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <releases>
+        <updatePolicy>daily</updatePolicy>
+        <checksumPolicy>ignore</checksumPolicy>
+      </releases>
+      <id>wso2-releases</id>
+      <name>WSO2 Releases Repository</name>
+      <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+      <id>wso2-snapshots</id>
+      <name>WSO2 Snapshot Repository</name>
+      <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <dependencies>
     <dependency>
       <groupId>org.apache.synapse</groupId>
@@ -93,6 +124,26 @@
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wso2.carbon.utils</groupId>
+      <artifactId>org.wso2.carbon.utils</artifactId>
+      <version>2.0.1</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wso2.carbon.secvault</groupId>
+      <artifactId>org.wso2.carbon.secvault.feature</artifactId>
+      <version>5.0.13</version>
+      <type>zip</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ws.commons.axiom</groupId>
+      <artifactId>axiom</artifactId>
+      <version>1.2.22</version>
+      <type>pom</type>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
   <properties>

--- a/src/jwtauthhandler/pom.xml
+++ b/src/jwtauthhandler/pom.xml
@@ -86,6 +86,23 @@
 			<artifactId>nimbus-jose-jwt</artifactId>
 			<version>5.4</version>
 		</dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.utils</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+         <dependency>
+            <groupId>org.wso2.carbon.secvault</groupId>
+            <artifactId>org.wso2.carbon.secvault.feature</artifactId>
+            <version>5.0.13</version>
+            <type>zip</type>
+         </dependency>
+    <dependency>
+    <groupId>org.apache.ws.commons.axiom</groupId>
+    <artifactId>axiom</artifactId>
+    <version>1.2.22</version>
+    <type>pom</type>
+</dependency>
 	</dependencies>
 	<!-- Include the Nimbus JWT class files in the jar, they are not on the 
 		classpath of the WSO2 ESB -->
@@ -117,4 +134,39 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
+	
+   <pluginRepositories>
+        <pluginRepository>
+            <id>wso2-nexus</id>
+            <name>WSO2 Public Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2-releases</id>
+            <name>WSO2 Releases Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>wso2-snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
The JWT Handler config requires that the password for the keyvault and private key be stored in the config file. This update enables the secrets in that referenced XML file to be encrypted using WSO2's standard cryptotool security vault and enables the auth handler to dynamically decrypt those secrets on load, providing a consistent model and mechanism for securing secrets.